### PR TITLE
fix(loadbalancer): update health check port logic to prioritize service health check port annotation when HealthCheckNodePort is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lint: ## Lint the files
 	@golint -set_exit_status ${PKG_LIST}
 
 test: ## Run unittests
-	@go test -short ${PKG_LIST}
+	@go test -v ${PKG_LIST}
 
 race: ## Run data race detector
 	@go test -race -short ${PKG_LIST}

--- a/pkg/provider/loadbalancer_features.go
+++ b/pkg/provider/loadbalancer_features.go
@@ -23,9 +23,16 @@ func GetMaxConnections(service *corev1.Service) (int, error) {
 func GetLoadbalancingPolicy(service *corev1.Service) (iaas.LoadbalancingPolicy, error) {
 	policy, err := getStringAnnotation(service, LoadbalancerAnnotationLoadbalancingPolicy, DefaultLoadbalancingPolicy)
 	if err != nil {
-		return iaas.LoadbalancingPolicy(policy), nil
+		return iaas.LoadbalancingPolicyRoundRobin, err
 	}
-	return iaas.LoadbalancingPolicy(policy), nil
+
+	// Validate the policy value
+	switch iaas.LoadbalancingPolicy(policy) {
+	case iaas.LoadbalancingPolicyRoundRobin, iaas.LoadbalancingPolicyRandom, iaas.LoadbalancingPolicyMagLev:
+		return iaas.LoadbalancingPolicy(policy), nil
+	default:
+		return iaas.LoadbalancingPolicyRoundRobin, fmt.Errorf("invalid loadbalancing policy: %s, must be one of: ROUND_ROBIN, RANDOM, MAGLEV", policy)
+	}
 }
 
 func getStringAnnotation(service *corev1.Service, annotation string, defaultValue string) (string, error) {

--- a/pkg/provider/loadbalancer_targetgroups.go
+++ b/pkg/provider/loadbalancer_targetgroups.go
@@ -86,8 +86,12 @@ func (l *loadbalancer) getDesiredVpcLoadbalancerTargetGroups(service *corev1.Ser
 		}
 
 		if service.Spec.HealthCheckNodePort > 0 {
+			port := int32(service.Spec.HealthCheckNodePort)
+			if healthCheckPort > 0 {
+				port = int32(healthCheckPort)
+			}
 			backend.HealthCheck = &iaas.BackendHealthCheck{
-				Port:               int32(service.Spec.HealthCheckNodePort),
+				Port:               port,
 				Protocol:           iaas.ProtocolHTTP,
 				Path:               healthCheckPath,
 				TimeoutSeconds:     healthCheckTimeoutSeconds,

--- a/pkg/provider/loadbalancer_targetgroups.go
+++ b/pkg/provider/loadbalancer_targetgroups.go
@@ -21,7 +21,7 @@ const (
 	DefaultHealthCheckProtocol           = "http"
 )
 
-func (l *loadbalancer) getDesiredVpcLoadbalancerTargetGroups(service *corev1.Service, nodes []*corev1.Node) ([]iaas.VpcLoadbalancerTargetGroup, error) {
+func (l *loadbalancer) getDesiredVpcLoadbalancerTargetGroups(service *corev1.Service, _ []*corev1.Node) ([]iaas.VpcLoadbalancerTargetGroup, error) {
 	tgs := []iaas.VpcLoadbalancerTargetGroup{}
 
 	enableProxyProtocol, err := getBoolAnnotation(service, LoadbalancerAnnotationEnableProxyProtocol, DefaultEnableProxyProtocol)
@@ -32,6 +32,7 @@ func (l *loadbalancer) getDesiredVpcLoadbalancerTargetGroups(service *corev1.Ser
 	loadbalancingPolicy, err := GetLoadbalancingPolicy(service)
 	if err != nil {
 		klog.Errorf("failed to get loadbalancing policy: %v", err)
+		return nil, err
 	}
 
 	healthCheckEnabled, err := getBoolAnnotation(service, LoadbalancerAnnotationHealthCheckEnabled, false)

--- a/pkg/provider/loadbalancer_targetgroups_test.go
+++ b/pkg/provider/loadbalancer_targetgroups_test.go
@@ -1,0 +1,474 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thalassa-cloud/client-go/iaas"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestGetDesiredVpcLoadbalancerTargetGroups(t *testing.T) {
+	tests := []struct {
+		name          string
+		service       *corev1.Service
+		expectedTGs   []iaas.VpcLoadbalancerTargetGroup
+		expectedError bool
+	}{
+		{
+			name: "basic target group with default values",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+					UID:       "test-uid-1",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: corev1.ProtocolTCP,
+							Port:     80,
+							NodePort: 30000,
+						},
+					},
+				},
+			},
+			expectedTGs: []iaas.VpcLoadbalancerTargetGroup{
+				{
+					Name:                "atestuid1-http",
+					TargetPort:          30000,
+					Protocol:            iaas.ProtocolTCP,
+					EnableProxyProtocol: ptr.To(false),
+					LoadbalancingPolicy: ptr.To(iaas.LoadbalancingPolicyRoundRobin),
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "target group with health check enabled",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+					UID:       "test-uid-2",
+					Annotations: map[string]string{
+						LoadbalancerAnnotationHealthCheckEnabled: "true",
+						LoadbalancerAnnotationHealthCheckPort:    "8080",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: corev1.ProtocolTCP,
+							Port:     80,
+							NodePort: 30000,
+						},
+					},
+				},
+			},
+			expectedTGs: []iaas.VpcLoadbalancerTargetGroup{
+				{
+					Name:                "atestuid2-http",
+					TargetPort:          30000,
+					Protocol:            iaas.ProtocolTCP,
+					EnableProxyProtocol: ptr.To(false),
+					LoadbalancingPolicy: ptr.To(iaas.LoadbalancingPolicyRoundRobin),
+					HealthCheck: &iaas.BackendHealthCheck{
+						Port:               8080,
+						Protocol:           iaas.ProtocolHTTP,
+						Path:               DefaultHealthCheckPath,
+						TimeoutSeconds:     DefaultHealthCheckTimeoutSeconds,
+						PeriodSeconds:      DefaultHealthCheckPeriodSeconds,
+						HealthyThreshold:   DefaultHealthCheckHealthyThreshold,
+						UnhealthyThreshold: DefaultHealthCheckUnhealthyThreshold,
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "target group with custom health check configuration",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+					UID:       "test-uid-3",
+					Annotations: map[string]string{
+						LoadbalancerAnnotationHealthCheckEnabled:       "true",
+						LoadbalancerAnnotationHealthCheckPort:          "8080",
+						LoadbalancerAnnotationHealthCheckPath:          "/custom-health",
+						LoadbalancerAnnotationHealthCheckTimeout:       "10",
+						LoadbalancerAnnotationHealthCheckInterval:      "20",
+						LoadbalancerAnnotationHealthCheckUpThreshold:   "3",
+						LoadbalancerAnnotationHealthCheckDownThreshold: "4",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: corev1.ProtocolTCP,
+							Port:     80,
+							NodePort: 30000,
+						},
+					},
+				},
+			},
+			expectedTGs: []iaas.VpcLoadbalancerTargetGroup{
+				{
+					Name:                "atestuid3-http",
+					TargetPort:          30000,
+					Protocol:            iaas.ProtocolTCP,
+					EnableProxyProtocol: ptr.To(false),
+					LoadbalancingPolicy: ptr.To(iaas.LoadbalancingPolicyRoundRobin),
+					HealthCheck: &iaas.BackendHealthCheck{
+						Port:               8080,
+						Protocol:           iaas.ProtocolHTTP,
+						Path:               "/custom-health",
+						TimeoutSeconds:     10,
+						PeriodSeconds:      20,
+						HealthyThreshold:   3,
+						UnhealthyThreshold: 4,
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "target group with proxy protocol enabled",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+					UID:       "test-uid-4",
+					Annotations: map[string]string{
+						LoadbalancerAnnotationEnableProxyProtocol: "true",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: corev1.ProtocolTCP,
+							Port:     80,
+							NodePort: 30000,
+						},
+					},
+				},
+			},
+			expectedTGs: []iaas.VpcLoadbalancerTargetGroup{
+				{
+					Name:                "atestuid4-http",
+					TargetPort:          30000,
+					Protocol:            iaas.ProtocolTCP,
+					EnableProxyProtocol: ptr.To(true),
+					LoadbalancingPolicy: ptr.To(iaas.LoadbalancingPolicyRoundRobin),
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "target group with custom loadbalancing policy",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+					UID:       "test-uid-5",
+					Annotations: map[string]string{
+						LoadbalancerAnnotationLoadbalancingPolicy: "MAGLEV",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: corev1.ProtocolTCP,
+							Port:     80,
+							NodePort: 30000,
+						},
+					},
+				},
+			},
+			expectedTGs: []iaas.VpcLoadbalancerTargetGroup{
+				{
+					Name:                "atestuid5-http",
+					TargetPort:          30000,
+					Protocol:            iaas.ProtocolTCP,
+					EnableProxyProtocol: ptr.To(false),
+					LoadbalancingPolicy: ptr.To(iaas.LoadbalancingPolicyMagLev),
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "service with multiple ports",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+					UID:       "test-uid-6",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: corev1.ProtocolTCP,
+							Port:     80,
+							NodePort: 30000,
+						},
+						{
+							Name:     "https",
+							Protocol: corev1.ProtocolTCP,
+							Port:     443,
+							NodePort: 30001,
+						},
+					},
+				},
+			},
+			expectedTGs: []iaas.VpcLoadbalancerTargetGroup{
+				{
+					Name:                "atestuid6-http",
+					TargetPort:          30000,
+					Protocol:            iaas.ProtocolTCP,
+					EnableProxyProtocol: ptr.To(false),
+					LoadbalancingPolicy: ptr.To(iaas.LoadbalancingPolicyRoundRobin),
+				},
+				{
+					Name:                "atestuid6-https",
+					TargetPort:          30001,
+					Protocol:            iaas.ProtocolTCP,
+					EnableProxyProtocol: ptr.To(false),
+					LoadbalancingPolicy: ptr.To(iaas.LoadbalancingPolicyRoundRobin),
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "service with HealthCheckNodePort for local traffic policy",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+					UID:       "test-uid-7",
+				},
+				Spec: corev1.ServiceSpec{
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+					HealthCheckNodePort:   31000,
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: corev1.ProtocolTCP,
+							Port:     80,
+							NodePort: 30000,
+						},
+					},
+				},
+			},
+			expectedTGs: []iaas.VpcLoadbalancerTargetGroup{
+				{
+					Name:                "atestuid7-http",
+					TargetPort:          30000,
+					Protocol:            iaas.ProtocolTCP,
+					EnableProxyProtocol: ptr.To(false),
+					LoadbalancingPolicy: ptr.To(iaas.LoadbalancingPolicyRoundRobin),
+					HealthCheck: &iaas.BackendHealthCheck{
+						Port:               31000,
+						Protocol:           iaas.ProtocolHTTP,
+						Path:               DefaultHealthCheckPath,
+						TimeoutSeconds:     DefaultHealthCheckTimeoutSeconds,
+						PeriodSeconds:      DefaultHealthCheckPeriodSeconds,
+						HealthyThreshold:   DefaultHealthCheckHealthyThreshold,
+						UnhealthyThreshold: DefaultHealthCheckUnhealthyThreshold,
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "service with HealthCheckNodePort and custom health check port",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+					UID:       "test-uid-8",
+					Annotations: map[string]string{
+						LoadbalancerAnnotationHealthCheckPort: "8080",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+					HealthCheckNodePort:   31000,
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: corev1.ProtocolTCP,
+							Port:     80,
+							NodePort: 30000,
+						},
+					},
+				},
+			},
+			expectedTGs: []iaas.VpcLoadbalancerTargetGroup{
+				{
+					Name:                "atestuid8-http",
+					TargetPort:          30000,
+					Protocol:            iaas.ProtocolTCP,
+					EnableProxyProtocol: ptr.To(false),
+					LoadbalancingPolicy: ptr.To(iaas.LoadbalancingPolicyRoundRobin),
+					HealthCheck: &iaas.BackendHealthCheck{
+						Port:               8080,
+						Protocol:           iaas.ProtocolHTTP,
+						Path:               DefaultHealthCheckPath,
+						TimeoutSeconds:     DefaultHealthCheckTimeoutSeconds,
+						PeriodSeconds:      DefaultHealthCheckPeriodSeconds,
+						HealthyThreshold:   DefaultHealthCheckHealthyThreshold,
+						UnhealthyThreshold: DefaultHealthCheckUnhealthyThreshold,
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "service with invalid health check timeout",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+					UID:       "test-uid-9",
+					Annotations: map[string]string{
+						LoadbalancerAnnotationHealthCheckEnabled: "true",
+						LoadbalancerAnnotationHealthCheckPort:    "8080",
+						LoadbalancerAnnotationHealthCheckTimeout: "invalid",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: corev1.ProtocolTCP,
+							Port:     80,
+							NodePort: 30000,
+						},
+					},
+				},
+			},
+			expectedTGs: []iaas.VpcLoadbalancerTargetGroup{
+				{
+					Name:                "atestuid9-http",
+					TargetPort:          30000,
+					Protocol:            iaas.ProtocolTCP,
+					EnableProxyProtocol: ptr.To(false),
+					LoadbalancingPolicy: ptr.To(iaas.LoadbalancingPolicyRoundRobin),
+					HealthCheck: &iaas.BackendHealthCheck{
+						Port:               8080,
+						Protocol:           iaas.ProtocolHTTP,
+						Path:               DefaultHealthCheckPath,
+						TimeoutSeconds:     DefaultHealthCheckTimeoutSeconds,
+						PeriodSeconds:      DefaultHealthCheckPeriodSeconds,
+						HealthyThreshold:   DefaultHealthCheckHealthyThreshold,
+						UnhealthyThreshold: DefaultHealthCheckUnhealthyThreshold,
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "service with invalid loadbalancing policy",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+					UID:       "test-uid-10",
+					Annotations: map[string]string{
+						LoadbalancerAnnotationLoadbalancingPolicy: "INVALID_POLICY",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: corev1.ProtocolTCP,
+							Port:     80,
+							NodePort: 30000,
+						},
+					},
+				},
+			},
+			expectedTGs:   nil,
+			expectedError: true,
+		},
+		{
+			name: "service with invalid proxy protocol value",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: "default",
+					UID:       "test-uid-11",
+					Annotations: map[string]string{
+						LoadbalancerAnnotationEnableProxyProtocol: "invalid",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Protocol: corev1.ProtocolTCP,
+							Port:     80,
+							NodePort: 30000,
+						},
+					},
+				},
+			},
+			expectedTGs: []iaas.VpcLoadbalancerTargetGroup{
+				{
+					Name:                "atestuid11-http",
+					TargetPort:          30000,
+					Protocol:            iaas.ProtocolTCP,
+					EnableProxyProtocol: ptr.To(false),
+					LoadbalancingPolicy: ptr.To(iaas.LoadbalancingPolicyRoundRobin),
+				},
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lb := &loadbalancer{}
+			tgs, err := lb.getDesiredVpcLoadbalancerTargetGroups(tt.service, nil)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, len(tt.expectedTGs), len(tgs))
+
+			for i, expectedTG := range tt.expectedTGs {
+				assert.Equal(t, expectedTG.Name, tgs[i].Name)
+				assert.Equal(t, expectedTG.TargetPort, tgs[i].TargetPort)
+				assert.Equal(t, expectedTG.Protocol, tgs[i].Protocol)
+				assert.Equal(t, expectedTG.EnableProxyProtocol, tgs[i].EnableProxyProtocol)
+				assert.Equal(t, expectedTG.LoadbalancingPolicy, tgs[i].LoadbalancingPolicy)
+
+				if expectedTG.HealthCheck != nil {
+					assert.NotNil(t, tgs[i].HealthCheck)
+					assert.Equal(t, expectedTG.HealthCheck.Port, tgs[i].HealthCheck.Port)
+					assert.Equal(t, expectedTG.HealthCheck.Protocol, tgs[i].HealthCheck.Protocol)
+					assert.Equal(t, expectedTG.HealthCheck.Path, tgs[i].HealthCheck.Path)
+					assert.Equal(t, expectedTG.HealthCheck.TimeoutSeconds, tgs[i].HealthCheck.TimeoutSeconds)
+					assert.Equal(t, expectedTG.HealthCheck.PeriodSeconds, tgs[i].HealthCheck.PeriodSeconds)
+					assert.Equal(t, expectedTG.HealthCheck.HealthyThreshold, tgs[i].HealthCheck.HealthyThreshold)
+					assert.Equal(t, expectedTG.HealthCheck.UnhealthyThreshold, tgs[i].HealthCheck.UnhealthyThreshold)
+				} else {
+					assert.Nil(t, tgs[i].HealthCheck)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
update health check port logic to prioritize service health check port annotation when HealthCheckNodePort is set

Modified the health check configuration to use the specified health check port from the service if available, ensuring more accurate health check behavior.