### PR TITLE
fix(instances): handle not found error in InstanceExists method

### DIFF
--- a/pkg/provider/instancesv2.go
+++ b/pkg/provider/instancesv2.go
@@ -37,6 +37,9 @@ func (i *instancesV2) InstanceExists(ctx context.Context, node *corev1.Node) (bo
 	}
 	vmi, err := i.iaasClient.GetMachine(ctx, instanceID)
 	if err != nil {
+		if thalassaclient.IsNotFound(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	if vmi == nil {


### PR DESCRIPTION
Updated the InstanceExists method to return false without an error when the machine is not found, improving error handling for non-existent instances.