### PR TITLE
feat(loadbalancer): add support for security group annotation allowing to assign security groups to load balancers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.2
 
 require (
 	github.com/stretchr/testify v1.10.0
-	github.com/thalassa-cloud/client-go v0.16.0
+	github.com/thalassa-cloud/client-go v0.17.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/thalassa-cloud/client-go v0.16.0 h1:WWP14C8cBv6bqC775tZqn7xTquFbFTtZ+BV1GdxkCfM=
-github.com/thalassa-cloud/client-go v0.16.0/go.mod h1:xrEjSH5hUorL4JwzDiE1Z+0JHJLodNE49rqluZdB6P8=
+github.com/thalassa-cloud/client-go v0.17.0 h1:8CRT5YY5eamciDLhL4HtJ+MIC/RpVFitDPImR/W9GVk=
+github.com/thalassa-cloud/client-go v0.17.0/go.mod h1:xrEjSH5hUorL4JwzDiE1Z+0JHJLodNE49rqluZdB6P8=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/pkg/provider/annotations.go
+++ b/pkg/provider/annotations.go
@@ -45,6 +45,9 @@ const (
 	// LoadbalancerAnnotationAclAllowedSources is a comma separated list of CIDR ranges that are allowed to access the loadbalancer listener ports. Default no ACL, allow any source
 	// CIDR ranges can be ipv4 or ipv6, but must be compatible with the public network used (i.g. ipv4 CIDR ranges for loadbalancers if the public network is ipv4)
 	LoadbalancerAnnotationAclAllowedSources = "loadbalancer.k8s.thalassa.cloud/acl-allowed-sources"
+
+	// LoadBalancerAnnotationSecurityGroups is a comma separated list of security group IDs to apply to the loadbalancer.
+	LoadBalancerAnnotationSecurityGroups = "loadbalancer.k8s.thalassa.cloud/security-groups"
 )
 
 const (

--- a/vendor/github.com/thalassa-cloud/client-go/iaas/machines.go
+++ b/vendor/github.com/thalassa-cloud/client-go/iaas/machines.go
@@ -205,18 +205,18 @@ type ListMachinesRequest struct {
 }
 
 type Machine struct {
-	Identity         string      `json:"identity"`
-	Name             string      `json:"name"`
-	Slug             string      `json:"slug"`
-	CreatedAt        time.Time   `json:"createdAt"`
-	UpdatedAt        *time.Time  `json:"updatedAt,omitempty"`
-	Description      *string     `json:"description,omitempty"`
-	Annotations      Annotations `json:"annotations,omitempty"`
-	Labels           Labels      `json:"labels,omitempty"`
-	State            MachineState
-	CloudInit        *string `json:"cloudInit"`
-	DeleteProtection bool    `json:"deleteProtection"`
-	// SecurityGroups    []SecurityGroup          `json:"securityGroups,omitempty"`
+	Identity          string      `json:"identity"`
+	Name              string      `json:"name"`
+	Slug              string      `json:"slug"`
+	CreatedAt         time.Time   `json:"createdAt"`
+	UpdatedAt         *time.Time  `json:"updatedAt,omitempty"`
+	Description       *string     `json:"description,omitempty"`
+	Annotations       Annotations `json:"annotations,omitempty"`
+	Labels            Labels      `json:"labels,omitempty"`
+	State             MachineState
+	CloudInit         *string                  `json:"cloudInit"`
+	DeleteProtection  bool                     `json:"deleteProtection"`
+	SecurityGroups    []SecurityGroup          `json:"securityGroups,omitempty"`
 	Organisation      *base.Organisation       `json:"organisation,omitempty"`
 	MachineType       *MachineType             `json:"machineType,omitempty"`
 	MachineImage      *MachineImage            `json:"machineImage,omitempty"`

--- a/vendor/github.com/thalassa-cloud/client-go/iaas/types.go
+++ b/vendor/github.com/thalassa-cloud/client-go/iaas/types.go
@@ -124,6 +124,9 @@ type VpcNatGateway struct {
 
 	V4IP string `json:"v4IP"`
 	V6IP string `json:"v6IP"`
+
+	// SecurityGroups is a list of security groups that are attached to the NAT Gateway.
+	SecurityGroups []SecurityGroup `json:"securityGroups"`
 }
 
 type VpcLoadbalancer struct {
@@ -149,6 +152,9 @@ type VpcLoadbalancer struct {
 	Hostname            string   `json:"hostname"`
 
 	LoadbalancerListeners []VpcLoadbalancerListener `json:"loadbalancerListeners"`
+
+	// SecurityGroups is a list of security groups that are attached to the Loadbalancer.
+	SecurityGroups []SecurityGroup `json:"securityGroups"`
 }
 
 type Volume struct {
@@ -397,13 +403,18 @@ type CreateVpcNatGateway struct {
 	Labels         Labels      `json:"labels"`
 	Annotations    Annotations `json:"annotations"`
 	SubnetIdentity string      `json:"subnetIdentity"`
+	// SecurityGroupAttachments is a list of security group identities to attach to the NAT Gateway
+	SecurityGroupAttachments []string `json:"securityGroupAttachments"`
+	// ConfigureDefaultRoute is a boolean indicating whether to configure the default route for the NAT Gateway for the route table of the subnet
+	ConfigureDefaultRoute bool `json:"configureDefaultRoute"`
 }
 
 type UpdateVpcNatGateway struct {
-	Name        string      `json:"name"`
-	Description string      `json:"description"`
-	Labels      Labels      `json:"labels"`
-	Annotations Annotations `json:"annotations"`
+	Name                     string      `json:"name"`
+	Description              string      `json:"description"`
+	Labels                   Labels      `json:"labels"`
+	Annotations              Annotations `json:"annotations"`
+	SecurityGroupAttachments []string    `json:"securityGroupAttachments"`
 }
 
 type CreateMachine struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -224,7 +224,7 @@ github.com/stoewer/go-strcase
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/assert/yaml
 github.com/stretchr/testify/require
-# github.com/thalassa-cloud/client-go v0.16.0
+# github.com/thalassa-cloud/client-go v0.17.0
 ## explicit; go 1.23.1
 github.com/thalassa-cloud/client-go/filters
 github.com/thalassa-cloud/client-go/iaas


### PR DESCRIPTION
add support for security group annotation allowing to assign security groups to load balancers.

Usage on a service annotations:
```yaml
loadbalancer.k8s.thalassa.cloud/security-groups: sg-1234, sg-abc123
```

This will automatically sync the security groups on the load balancer.
